### PR TITLE
Changed dependency version for metrics.reader

### DIFF
--- a/statsd/pom.xml
+++ b/statsd/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>org.kaazing</groupId>
             <artifactId>metrics.reader</artifactId>
-            <version>develop-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
     </dependencies>
 

--- a/viewer/pom.xml
+++ b/viewer/pom.xml
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>org.kaazing</groupId>
             <artifactId>metrics.reader</artifactId>
-            <version>develop-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Changed dependency version for metrics.reader from develop-SNAPSHOT to ${project.version}
