### PR TITLE
Enhance metrics.statsd startup scripts so they can be called from anywhere, plus minor test changes

### DIFF
--- a/reader/src/test/java/org/kaazing/monitoring/reader/agrona/extension/CountersManagerExTest.java
+++ b/reader/src/test/java/org/kaazing/monitoring/reader/agrona/extension/CountersManagerExTest.java
@@ -34,7 +34,7 @@ import uk.co.real_logic.agrona.concurrent.AtomicBuffer;
 public class CountersManagerExTest {
 
     @Test
-    public void testGetLongValueForIdShouldReturnCounterValue() {
+    public void getLongValueForIdShouldReturnCounterValue() {
         Mockery context = new Mockery();
 
         context.setImposteriser(ClassImposteriser.INSTANCE);

--- a/reader/src/test/java/org/kaazing/monitoring/reader/file/location/impl/MonitoringFolderAgronaImplTest.java
+++ b/reader/src/test/java/org/kaazing/monitoring/reader/file/location/impl/MonitoringFolderAgronaImplTest.java
@@ -42,7 +42,7 @@ public class MonitoringFolderAgronaImplTest {
     private static final long TIMESTAMP = (new Date()).getTime();
 
     @Test
-    public void testGetMonitoringFilesShouldReturnEmptyList() {
+    public void getMonitoringFilesShouldReturnEmptyList() {
         MonitoringFolderAgrona monitoringFolder = new MonitoringFolderAgronaImplMonitoringDirMocked();
         List<String> files = monitoringFolder.getMonitoringFiles();
         assertNotNull(files);
@@ -51,32 +51,37 @@ public class MonitoringFolderAgronaImplTest {
     }
 
     @Test
-    public void testGetMonitoringFilesShouldReturnNonEmptyList() {
+    public void getMonitoringFilesShouldReturnNonEmptyList() {
         MonitoringFolderAgrona monitoringFolder = new MonitoringFolderAgronaImplMonitoringDirMocked();
         String folder = monitoringFolder.getMonitoringDir();
         File directory = new File(folder);
         File file1 = new File(folder + "/test1");
         File file2 = new File(folder + "/test2");
-        boolean created = directory.mkdirs();
-        assertEquals(true, created);
         try {
-            file1.createNewFile();
-            file2.createNewFile();
-        } catch (IOException e) {
-            e.printStackTrace();
+            boolean created = directory.mkdirs();
+            assertEquals(true, created);
+            try {
+                file1.createNewFile();
+                file2.createNewFile();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+            List<String> files = monitoringFolder.getMonitoringFiles();
+            assertNotNull(files);
+            //no monitoring files should be present by default
+            assertEquals(2, files.size());
+
         }
-        List<String> files = monitoringFolder.getMonitoringFiles();
-        assertNotNull(files);
-        //no monitoring files should be present by default
-        assertEquals(2, files.size());
-        //cleanup files
-        file1.delete();
-        file2.delete();
-        directory.delete();
+        finally {
+            // always cleanup files, even if there is an exception
+            file1.delete();
+            file2.delete();
+            directory.delete();
+        }
     }
 
     @Test
-    public void testGetMonitoringDir() {
+    public void getMonitoringDirShouldReturnConfiguredDirectoryNameInCorrectLocation() {
         MonitoringFolderAgrona monitoringFolder = new MonitoringFolderAgronaImpl();
         String monitoringDir = "";
         if (LINUX.equals(System.getProperty(OS_NAME))) {

--- a/reader/src/test/java/org/kaazing/monitoring/reader/impl/MetricsCollectorAgronaTest.java
+++ b/reader/src/test/java/org/kaazing/monitoring/reader/impl/MetricsCollectorAgronaTest.java
@@ -42,7 +42,7 @@ public class MetricsCollectorAgronaTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    public void testGetMetricsShouldReturnEmptyList() {
+    public void getMetricsShouldReturnEmptyList() {
         context.setImposteriser(ClassImposteriser.INSTANCE);
         CountersManagerEx counterManager = context.mock(CountersManagerEx.class);
         context.checking(new Expectations() {{
@@ -52,6 +52,7 @@ public class MetricsCollectorAgronaTest {
         assertNotNull(collector.getMetrics());
     }
 
+    @SuppressWarnings("unchecked")
     @Test
     public void getMetricsShouldReturnAvailableMetrics () {
         context.setImposteriser(ClassImposteriser.INSTANCE);

--- a/statsd/src/main/scripts/metrics.statsd.start
+++ b/statsd/src/main/scripts/metrics.statsd.start
@@ -1,3 +1,12 @@
 #!/bin/bash
 
+# Go to the directory containing this script
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+cd -P "$( dirname "$SOURCE" )"
+
 java -XX:+HeapDumpOnOutOfMemoryError -jar ../lib/metrics.statsd-develop-SNAPSHOT.jar "$@"

--- a/statsd/src/main/scripts/metrics.statsd.start.bat
+++ b/statsd/src/main/scripts/metrics.statsd.start.bat
@@ -1,1 +1,2 @@
+cd %~dp0
 java -XX:+HeapDumpOnOutOfMemoryError -jar ../lib/metrics.statsd-develop-SNAPSHOT.jar %*


### PR DESCRIPTION
 (rename a couple test methods to avoid redundant "test" prefix, always delete files, avoid compiler warnings) from review of pull request #7.

**Please test the modified metrics.statsd.start script on Linux (and Mac OS if possible) to make sure it works. I have only tested it using bash on Windows.**
